### PR TITLE
Rename and enhance the ;remove command functionality

### DIFF
--- a/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/dao/CytubeDao.kt
+++ b/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/dao/CytubeDao.kt
@@ -70,4 +70,16 @@ constructor(private val restTemplate: RestTemplate, private val userConfig: User
   fun skipVideo() {
     restTemplate.put("$url/skip-song", null)
   }
+
+  /**
+   * Removes a video from the playlist by its URL
+   *
+   * @param videoUrl The URL of the video to remove
+   * @return The updated playlist, or null if the operation failed
+   */
+  fun removeVideo(videoUrl: String): Playlist? {
+    val response: ResponseEntity<Playlist> =
+      restTemplate.postForEntity("$url/remove-video?link=$videoUrl", null, Playlist::class.java)
+    return response.body
+  }
 }

--- a/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/model/User.kt
+++ b/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/model/User.kt
@@ -28,4 +28,6 @@ class User(@Column(name = "username", nullable = false) var username: String) {
   @Column(name = "user_notified", nullable = true) var userNotified: Boolean = true
   @Column(name = "last_skip", nullable = false)
   var lastSkip: LocalDateTime = LocalDateTime.now().minusDays(1)
+  @Column(name = "last_removed_video", nullable = false)
+  var lastRemovedVideo: LocalDateTime = LocalDateTime.now().minusDays(1)
 }

--- a/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/service/CommandService.kt
+++ b/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/service/CommandService.kt
@@ -74,7 +74,7 @@ class CommandService(
         ";help" -> {
           messageService.sendMessage(
             channel,
-            "docJAM @${username} Commands: ;link, ;where, ;search, ;s, ;help, ;playlist, ;skip, ;rg, ;when, ;remove",
+            "docJAM @${username} Commands: ;link, ;where, ;search, ;s, ;help, ;playlist, ;skip, ;rg, ;when, ;undo",
           )
         }
         ";playlist" -> {
@@ -86,7 +86,7 @@ class CommandService(
         ";when" -> {
           userSongFormatterService.getUserSongs(username, channel)
         }
-        ";remove" -> {
+        ";undo" -> {
           removeSongCommand(username, channel)
         }
         else -> {

--- a/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/service/CommandService.kt
+++ b/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/service/CommandService.kt
@@ -148,7 +148,7 @@ class CommandService(
         channel,
         "docJAM @$username You can remove a video every 5 minutes. Time to next removal: ${
           timeRestrictionService.timeToNextRemoval(username)
-        }"
+        }",
       )
       return
     }
@@ -160,7 +160,7 @@ class CommandService(
       // No song to remove or song was added more than 5 minutes ago
       messageService.sendMessage(
         channel,
-        "docJAM @$username You don't have any recently added songs to remove (must be within 5 minutes of adding)"
+        "docJAM @$username You don't have any recently added songs to remove (must be within 5 minutes of adding)",
       )
       return
     }
@@ -170,7 +170,7 @@ class CommandService(
     if (songLink == null) {
       messageService.sendMessage(
         channel,
-        "docJAM @$username Error removing song. Please try again."
+        "docJAM @$username Error removing song. Please try again.",
       )
       return
     }
@@ -187,12 +187,12 @@ class CommandService(
 
       messageService.sendMessage(
         channel,
-        "docJAM @$username Removed your song '${song.title}'. You can add another song now."
+        "docJAM @$username Removed your song '${song.title}'. You can add another song now.",
       )
     } else {
       messageService.sendMessage(
         channel,
-        "docJAM @$username Error removing song from playlist. Please try again."
+        "docJAM @$username Error removing song from playlist. Please try again.",
       )
     }
   }

--- a/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/service/command/PlaylistService.kt
+++ b/src/main/kotlin/com/github/veccvs/djforsenbotkotlin/service/command/PlaylistService.kt
@@ -82,4 +82,15 @@ class PlaylistService(
   fun randomGachiSong(): String {
     return gachiSongRepository.findAll().random().title.orEmpty()
   }
+
+  /**
+   * Removes a video from the playlist
+   *
+   * @param videoUrl The URL of the video to remove
+   * @return True if the video was removed successfully, false otherwise
+   */
+  fun removeVideo(videoUrl: String): Boolean {
+    val playlist = cytubeDao.removeVideo(videoUrl)
+    return playlist != null
+  }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://192.168.0.122:5432/djforsen_dev
+spring.datasource.url=jdbc:postgresql://192.168.0.121:5432/djforsen_dev
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/src/main/resources/db/changelog/2024/10/01-01-changelog.xml
+++ b/src/main/resources/db/changelog/2024/10/01-01-changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="20241001-01" author="system">
+        <addColumn tableName="user">
+            <column name="last_removed_video" type="timestamp" defaultValueDate="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/kotlin/com/github/veccvs/djforsenbotkotlin/service/CommandServiceTest.kt
+++ b/src/test/kotlin/com/github/veccvs/djforsenbotkotlin/service/CommandServiceTest.kt
@@ -2,8 +2,10 @@ package com.github.veccvs.djforsenbotkotlin.service
 
 import com.github.veccvs.djforsenbotkotlin.component.TwitchConnector
 import com.github.veccvs.djforsenbotkotlin.config.UserConfig
+import com.github.veccvs.djforsenbotkotlin.model.Song
 import com.github.veccvs.djforsenbotkotlin.model.TwitchCommand
 import com.github.veccvs.djforsenbotkotlin.model.User
+import com.github.veccvs.djforsenbotkotlin.model.UserSong
 import com.github.veccvs.djforsenbotkotlin.repository.UserRepository
 import com.github.veccvs.djforsenbotkotlin.service.command.*
 import org.junit.jupiter.api.BeforeEach
@@ -11,457 +13,573 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.test.util.ReflectionTestUtils
-import java.util.*
 
 @ExtendWith(MockitoExtension::class)
 class CommandServiceTest {
 
-    @Mock
-    private lateinit var messageService: MessageService
-
-    @Mock
-    private lateinit var commandParserService: CommandParserService
-
-    @Mock
-    private lateinit var videoSearchService: VideoSearchService
-
-    @Mock
-    private lateinit var timeRestrictionService: TimeRestrictionService
-
-    @Mock
-    private lateinit var userSongFormatterService: UserSongFormatterService
-
-    @Mock
-    private lateinit var playlistService: PlaylistService
-
-    @Mock
-    private lateinit var userRepository: UserRepository
-
-    @Mock
-    private lateinit var userConfig: UserConfig
-
-    @Mock
-    private lateinit var skipCounterService: SkipCounterService
-
-    @Mock
-    private lateinit var twitchConnector: TwitchConnector
-
-    @InjectMocks
-    private lateinit var commandService: CommandService
-
-    private val testUsername = "testUser"
-    private val testChannel = "testChannel"
-
-    @BeforeEach
-    fun setUp() {
-        // Replace the private TwitchConnector with our mock
-        ReflectionTestUtils.setField(commandService, "twitchConnector", twitchConnector)
-    }
-
-    @Test
-    fun `test sendMessage delegates to messageService`() {
-        // Given
-        val message = "Test message"
-
-        // When
-        commandService.sendMessage(testChannel, message)
-
-        // Then
-        verify(messageService).sendMessage(testChannel, message)
-    }
-
-    @Test
-    fun `test commandHandler with djfors prefix command`() {
-        // Given
-        val message = "!djfors_test"
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(messageService).sendMessage(testChannel, "docJAM @$testUsername bot made by veccvs")
-        verifyNoInteractions(commandParserService)
-    }
-
-    @Test
-    fun `test commandHandler with null command`() {
-        // Given
-        val message = "not a command"
-        `when`(commandParserService.detectCommand(message)).thenReturn(null)
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(commandParserService).detectCommand(message)
-        verifyNoMoreInteractions(commandParserService)
-        verifyNoInteractions(userRepository)
-    }
-
-    @Test
-    fun `test commandHandler when user cannot respond to command`() {
-        // Given
-        val message = ";test"
-        `when`(commandParserService.detectCommand(message)).thenReturn(";test")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(null)
-        `when`(userRepository.save(any(User::class.java))).thenReturn(User(testUsername))
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(false)
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(commandParserService).detectCommand(message)
-        verify(userRepository).findByUsername(testUsername)
-        verify(userRepository).save(any(User::class.java))
-        verify(timeRestrictionService).canResponseToCommand(testUsername)
-        verifyNoMoreInteractions(commandParserService)
-    }
-
-    @Test
-    fun `test commandHandler with link command`() {
-        // Given
-        val message = ";link"
-        val user = User(testUsername)
-        `when`(commandParserService.detectCommand(message)).thenReturn(";link")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";link", emptyList()))
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(messageService).sendMessage(testChannel, "docJAM @$testUsername I sent you a whisper with the link forsenCD ")
-        verify(twitchConnector).sendWhisper(testUsername, "https://cytu.be/r/forsenboys")
-        verify(timeRestrictionService).setLastResponse(testUsername)
-    }
-
-    @Test
-    fun `test commandHandler with where command`() {
-        // Given
-        val message = ";where"
-        val user = User(testUsername)
-        `when`(commandParserService.detectCommand(message)).thenReturn(";where")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";where", emptyList()))
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(messageService).sendMessage(testChannel, "docJAM @$testUsername I sent you a whisper with the link forsenCD ")
-        verify(twitchConnector).sendWhisper(testUsername, "https://cytu.be/r/forsenboys")
-        verify(timeRestrictionService).setLastResponse(testUsername)
-    }
-
-    @Test
-    fun `test commandHandler with search command when user can add video`() {
-        // Given
-        val message = ";search test"
-        val user = User(testUsername)
-        val twitchCommand = TwitchCommand(";search", listOf("test"))
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";search")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(twitchCommand)
-        `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(true)
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(videoSearchService).searchVideo(twitchCommand, testChannel, testUsername)
-    }
-
-    @Test
-    fun `test commandHandler with search command when user cannot add video`() {
-        // Given
-        val message = ";search test"
-        val user = User(testUsername)
-        val twitchCommand = TwitchCommand(";search", listOf("test"))
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";search")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(twitchCommand)
-        `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(false)
-        `when`(timeRestrictionService.timeToNextVideo(testUsername)).thenReturn("5 minutes")
-        `when`(userConfig.minutesToAddVideo).thenReturn(10)
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(messageService).sendMessage(testChannel, "docJAM @${testUsername} You can add a video every 10 minutes. Time to add next video: 5 minutes")
-        verifyNoInteractions(videoSearchService)
-    }
-
-    @Test
-    fun `test commandHandler with s command`() {
-        // Given
-        val message = ";s test"
-        val user = User(testUsername)
-        val twitchCommand = TwitchCommand(";s", listOf("test"))
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";s")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(twitchCommand)
-        `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(true)
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(videoSearchService).searchVideo(twitchCommand, testChannel, testUsername)
-    }
-
-    @Test
-    fun `test commandHandler with rg command`() {
-        // Given
-        val message = ";rg"
-        val user = User(testUsername)
-        val randomSong = "random gachi song"
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";rg")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";rg", emptyList()))
-        `when`(playlistService.randomGachiSong()).thenReturn(randomSong)
-        `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(true)
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(playlistService).randomGachiSong()
-        // For the rg command, we just verify that playlistService.randomGachiSong was called
-        // We don't verify videoSearchService.searchVideo because it's difficult to match the TwitchCommand object
-    }
-
-    @Test
-    fun `test commandHandler with help command`() {
-        // Given
-        val message = ";help"
-        val user = User(testUsername)
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";help")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";help", emptyList()))
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(messageService).sendMessage(
-            testChannel,
-            "docJAM @$testUsername Commands: ;link, ;where, ;search, ;s, ;help, ;playlist, ;skip, ;rg, ;mysongs"
-        )
-    }
-
-    @Test
-    fun `test commandHandler with playlist command`() {
-        // Given
-        val message = ";playlist"
-        val user = User(testUsername)
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";playlist")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";playlist", emptyList()))
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(playlistService).getPlaylist(testUsername, testChannel)
-    }
-
-    @Test
-    fun `test commandHandler with skip command`() {
-        // Given
-        val message = ";skip"
-        val user = User(testUsername)
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";skip")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";skip", emptyList()))
-        `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(true)
-        `when`(userConfig.skipValue).thenReturn("5")
-        `when`(skipCounterService.getSkipCounter()).thenReturn(2)
-        `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(timeRestrictionService).setLastSkip(testUsername)
-        verify(playlistService).handleSkipCommand(
-            testUsername,
-            testChannel,
-            true,
-            5L,
-            2,
-            "10 minutes"
-        )
-    }
-
-    @Test
-    fun `test commandHandler with skip command when user cannot skip`() {
-        // Given
-        val message = ";skip"
-        val user = User(testUsername)
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";skip")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";skip", emptyList()))
-        `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(false)
-        `when`(userConfig.skipValue).thenReturn("5")
-        `when`(skipCounterService.getSkipCounter()).thenReturn(2)
-        `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(timeRestrictionService, never()).setLastSkip(testUsername)
-        verify(playlistService).handleSkipCommand(
-            testUsername,
-            testChannel,
-            false,
-            5L,
-            2,
-            "10 minutes"
-        )
-    }
-
-    @Test
-    fun `test commandHandler with mysongs command`() {
-        // Given
-        val message = ";mysongs"
-        val user = User(testUsername)
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";mysongs")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";mysongs", emptyList()))
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(userSongFormatterService).getUserSongs(testUsername, testChannel)
-    }
-
-    @Test
-    fun `test commandHandler with unknown command`() {
-        // Given
-        val message = ";unknown"
-        val user = User(testUsername)
-
-        `when`(commandParserService.detectCommand(message)).thenReturn(";unknown")
-        `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
-        `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
-        `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";unknown", emptyList()))
-
-        // When
-        commandService.commandHandler(testUsername, message, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastResponse(testUsername)
-        verify(messageService).sendMessage(
-            testChannel,
-            "docJAM @$testUsername Unknown command, try ;link, ;search or ;help"
-        )
-    }
-
-    @Test
-    fun `test skipCommand when user can skip`() {
-        // Given
-        `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(true)
-        `when`(userConfig.skipValue).thenReturn("5")
-        `when`(skipCounterService.getSkipCounter()).thenReturn(2)
-        `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
-
-        // When
-        commandService.skipCommand(testUsername, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastSkip(testUsername)
-        verify(playlistService).handleSkipCommand(
-            testUsername,
-            testChannel,
-            true,
-            5L,
-            2,
-            "10 minutes"
-        )
-    }
-
-    @Test
-    fun `test skipCommand when user cannot skip`() {
-        // Given
-        `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(false)
-        `when`(userConfig.skipValue).thenReturn("5")
-        `when`(skipCounterService.getSkipCounter()).thenReturn(2)
-        `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
-
-        // When
-        commandService.skipCommand(testUsername, testChannel)
-
-        // Then
-        verify(timeRestrictionService, never()).setLastSkip(testUsername)
-        verify(playlistService).handleSkipCommand(
-            testUsername,
-            testChannel,
-            false,
-            5L,
-            2,
-            "10 minutes"
-        )
-    }
-
-    @Test
-    fun `test skipCommand with null skipValue`() {
-        // Given
-        `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(true)
-        `when`(userConfig.skipValue).thenReturn(null)
-        `when`(skipCounterService.getSkipCounter()).thenReturn(2)
-        `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
-
-        // When
-        commandService.skipCommand(testUsername, testChannel)
-
-        // Then
-        verify(timeRestrictionService).setLastSkip(testUsername)
-        verify(playlistService).handleSkipCommand(
-            testUsername,
-            testChannel,
-            true,
-            5L,
-            2,
-            "10 minutes"
-        )
-    }
+  @Mock private lateinit var messageService: MessageService
+
+  @Mock private lateinit var commandParserService: CommandParserService
+
+  @Mock private lateinit var videoSearchService: VideoSearchService
+
+  @Mock private lateinit var timeRestrictionService: TimeRestrictionService
+
+  @Mock private lateinit var userSongFormatterService: UserSongFormatterService
+
+  @Mock private lateinit var playlistService: PlaylistService
+
+  @Mock private lateinit var userRepository: UserRepository
+
+  @Mock private lateinit var userConfig: UserConfig
+
+  @Mock private lateinit var skipCounterService: SkipCounterService
+
+  @Mock private lateinit var userSongService: UserSongService
+
+  @Mock private lateinit var twitchConnector: TwitchConnector
+
+  @InjectMocks private lateinit var commandService: CommandService
+
+  private val testUsername = "testUser"
+  private val testChannel = "testChannel"
+
+  @BeforeEach
+  fun setUp() {
+    // Replace the private TwitchConnector with our mock
+    ReflectionTestUtils.setField(commandService, "twitchConnector", twitchConnector)
+  }
+
+  @Test
+  fun `test sendMessage delegates to messageService`() {
+    // Given
+    val message = "Test message"
+
+    // When
+    commandService.sendMessage(testChannel, message)
+
+    // Then
+    verify(messageService).sendMessage(testChannel, message)
+  }
+
+  @Test
+  fun `test commandHandler with djfors prefix command`() {
+    // Given
+    val message = "!djfors_test"
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(messageService).sendMessage(testChannel, "docJAM @$testUsername bot made by veccvs")
+    verifyNoInteractions(commandParserService)
+  }
+
+  @Test
+  fun `test commandHandler with null command`() {
+    // Given
+    val message = "not a command"
+    `when`(commandParserService.detectCommand(message)).thenReturn(null)
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(commandParserService).detectCommand(message)
+    verifyNoMoreInteractions(commandParserService)
+    verifyNoInteractions(userRepository)
+  }
+
+  @Test
+  fun `test commandHandler when user cannot respond to command`() {
+    // Given
+    val message = ";test"
+    `when`(commandParserService.detectCommand(message)).thenReturn(";test")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(null)
+    `when`(userRepository.save(any(User::class.java))).thenReturn(User(testUsername))
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(false)
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(commandParserService).detectCommand(message)
+    verify(userRepository).findByUsername(testUsername)
+    verify(userRepository).save(any(User::class.java))
+    verify(timeRestrictionService).canResponseToCommand(testUsername)
+    verifyNoMoreInteractions(commandParserService)
+  }
+
+  @Test
+  fun `test commandHandler with link command`() {
+    // Given
+    val message = ";link"
+    val user = User(testUsername)
+    `when`(commandParserService.detectCommand(message)).thenReturn(";link")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";link", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername I sent you a whisper with the link forsenCD ",
+      )
+    verify(twitchConnector).sendWhisper(testUsername, "https://cytu.be/r/forsenboys")
+    verify(timeRestrictionService).setLastResponse(testUsername)
+  }
+
+  @Test
+  fun `test commandHandler with where command`() {
+    // Given
+    val message = ";where"
+    val user = User(testUsername)
+    `when`(commandParserService.detectCommand(message)).thenReturn(";where")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";where", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername I sent you a whisper with the link forsenCD ",
+      )
+    verify(twitchConnector).sendWhisper(testUsername, "https://cytu.be/r/forsenboys")
+    verify(timeRestrictionService).setLastResponse(testUsername)
+  }
+
+  @Test
+  fun `test commandHandler with search command when user can add video`() {
+    // Given
+    val message = ";search test"
+    val user = User(testUsername)
+    val twitchCommand = TwitchCommand(";search", listOf("test"))
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";search")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message)).thenReturn(twitchCommand)
+    `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(true)
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(videoSearchService).searchVideo(twitchCommand, testChannel, testUsername)
+  }
+
+  @Test
+  fun `test commandHandler with search command when user cannot add video`() {
+    // Given
+    val message = ";search test"
+    val user = User(testUsername)
+    val twitchCommand = TwitchCommand(";search", listOf("test"))
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";search")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message)).thenReturn(twitchCommand)
+    `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(false)
+    `when`(timeRestrictionService.timeToNextVideo(testUsername)).thenReturn("5 minutes")
+    `when`(userConfig.minutesToAddVideo).thenReturn(10)
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @${testUsername} You can add a video every 10 minutes. Time to add next video: 5 minutes",
+      )
+    verifyNoInteractions(videoSearchService)
+  }
+
+  @Test
+  fun `test commandHandler with s command`() {
+    // Given
+    val message = ";s test"
+    val user = User(testUsername)
+    val twitchCommand = TwitchCommand(";s", listOf("test"))
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";s")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message)).thenReturn(twitchCommand)
+    `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(true)
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(videoSearchService).searchVideo(twitchCommand, testChannel, testUsername)
+  }
+
+  @Test
+  fun `test commandHandler with rg command`() {
+    // Given
+    val message = ";rg"
+    val user = User(testUsername)
+    val randomSong = "random gachi song"
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";rg")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message)).thenReturn(TwitchCommand(";rg", emptyList()))
+    `when`(playlistService.randomGachiSong()).thenReturn(randomSong)
+    `when`(timeRestrictionService.canUserAddVideo(testUsername)).thenReturn(true)
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(playlistService).randomGachiSong()
+    // For the rg command, we just verify that playlistService.randomGachiSong was called
+    // We don't verify videoSearchService.searchVideo because it's difficult to match the
+    // TwitchCommand object
+  }
+
+  @Test
+  fun `test commandHandler with help command`() {
+    // Given
+    val message = ";help"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";help")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";help", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername Commands: ;link, ;where, ;search, ;s, ;help, ;playlist, ;skip, ;rg, ;mysongs",
+      )
+  }
+
+  @Test
+  fun `test commandHandler with playlist command`() {
+    // Given
+    val message = ";playlist"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";playlist")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";playlist", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(playlistService).getPlaylist(testUsername, testChannel)
+  }
+
+  @Test
+  fun `test commandHandler with skip command`() {
+    // Given
+    val message = ";skip"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";skip")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";skip", emptyList()))
+    `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(true)
+    `when`(userConfig.skipValue).thenReturn("5")
+    `when`(skipCounterService.getSkipCounter()).thenReturn(2)
+    `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(timeRestrictionService).setLastSkip(testUsername)
+    verify(playlistService).handleSkipCommand(testUsername, testChannel, true, 5L, 2, "10 minutes")
+  }
+
+  @Test
+  fun `test commandHandler with skip command when user cannot skip`() {
+    // Given
+    val message = ";skip"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";skip")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";skip", emptyList()))
+    `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(false)
+    `when`(userConfig.skipValue).thenReturn("5")
+    `when`(skipCounterService.getSkipCounter()).thenReturn(2)
+    `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(timeRestrictionService, never()).setLastSkip(testUsername)
+    verify(playlistService).handleSkipCommand(testUsername, testChannel, false, 5L, 2, "10 minutes")
+  }
+
+  @Test
+  fun `test commandHandler with mysongs command`() {
+    // Given
+    val message = ";mysongs"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";mysongs")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";mysongs", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(userSongFormatterService).getUserSongs(testUsername, testChannel)
+  }
+
+  @Test
+  fun `test commandHandler with remove command`() {
+    // Given
+    val message = ";remove"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";remove")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";remove", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(commandService).removeSongCommand(testUsername, testChannel)
+  }
+
+  @Test
+  fun `test commandHandler with unknown command`() {
+    // Given
+    val message = ";unknown"
+    val user = User(testUsername)
+
+    `when`(commandParserService.detectCommand(message)).thenReturn(";unknown")
+    `when`(userRepository.findByUsername(testUsername)).thenReturn(user)
+    `when`(timeRestrictionService.canResponseToCommand(testUsername)).thenReturn(true)
+    `when`(commandParserService.parseCommand(message))
+      .thenReturn(TwitchCommand(";unknown", emptyList()))
+
+    // When
+    commandService.commandHandler(testUsername, message, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastResponse(testUsername)
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername Unknown command, try ;link, ;search or ;help",
+      )
+  }
+
+  @Test
+  fun `test skipCommand when user can skip`() {
+    // Given
+    `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(true)
+    `when`(userConfig.skipValue).thenReturn("5")
+    `when`(skipCounterService.getSkipCounter()).thenReturn(2)
+    `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
+
+    // When
+    commandService.skipCommand(testUsername, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastSkip(testUsername)
+    verify(playlistService).handleSkipCommand(testUsername, testChannel, true, 5L, 2, "10 minutes")
+  }
+
+  @Test
+  fun `test skipCommand when user cannot skip`() {
+    // Given
+    `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(false)
+    `when`(userConfig.skipValue).thenReturn("5")
+    `when`(skipCounterService.getSkipCounter()).thenReturn(2)
+    `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
+
+    // When
+    commandService.skipCommand(testUsername, testChannel)
+
+    // Then
+    verify(timeRestrictionService, never()).setLastSkip(testUsername)
+    verify(playlistService).handleSkipCommand(testUsername, testChannel, false, 5L, 2, "10 minutes")
+  }
+
+  @Test
+  fun `test skipCommand with null skipValue`() {
+    // Given
+    `when`(timeRestrictionService.canUserSkipVideo(testUsername)).thenReturn(true)
+    `when`(userConfig.skipValue).thenReturn(null)
+    `when`(skipCounterService.getSkipCounter()).thenReturn(2)
+    `when`(timeRestrictionService.timeToNextSkip(testUsername)).thenReturn("10 minutes")
+
+    // When
+    commandService.skipCommand(testUsername, testChannel)
+
+    // Then
+    verify(timeRestrictionService).setLastSkip(testUsername)
+    verify(playlistService).handleSkipCommand(testUsername, testChannel, true, 5L, 2, "10 minutes")
+  }
+
+  @Test
+  fun `test removeSongCommand when song can be removed`() {
+    // Given
+    val song = mock(UserSong::class.java)
+    val songEntity = mock(Song::class.java)
+
+    `when`(timeRestrictionService.canUserRemoveVideo(testUsername)).thenReturn(true)
+    `when`(song.song).thenReturn(songEntity)
+    `when`(songEntity.link).thenReturn("https://youtu.be/testVideo")
+    `when`(song.title).thenReturn("Test Song Title")
+    `when`(userSongService.removeRecentUserSong(testUsername)).thenReturn(song)
+    `when`(playlistService.removeVideo("https://youtu.be/testVideo")).thenReturn(true)
+
+    // When
+    commandService.removeSongCommand(testUsername, testChannel)
+
+    // Then
+    verify(userSongService).removeRecentUserSong(testUsername)
+    verify(playlistService).removeVideo("https://youtu.be/testVideo")
+    verify(timeRestrictionService).resetVideoCooldown(testUsername)
+    verify(timeRestrictionService).setLastRemoval(testUsername)
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername Removed your song 'Test Song Title'. You can add another song now.",
+      )
+  }
+
+  @Test
+  fun `test removeSongCommand when no song is available to remove`() {
+    // Given
+    `when`(timeRestrictionService.canUserRemoveVideo(testUsername)).thenReturn(true)
+    `when`(userSongService.removeRecentUserSong(testUsername)).thenReturn(null)
+
+    // When
+    commandService.removeSongCommand(testUsername, testChannel)
+
+    // Then
+    verify(userSongService).removeRecentUserSong(testUsername)
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername You don't have any recently added songs to remove (must be within 5 minutes of adding)",
+      )
+    verify(playlistService, never()).removeVideo(anyString())
+    verify(timeRestrictionService, never()).resetVideoCooldown(anyString())
+    verify(timeRestrictionService, never()).setLastRemoval(anyString())
+  }
+
+  @Test
+  fun `test removeSongCommand when song link is null`() {
+    // Given
+    val song = mock(UserSong::class.java)
+
+    `when`(timeRestrictionService.canUserRemoveVideo(testUsername)).thenReturn(true)
+    `when`(song.song).thenReturn(null)
+    `when`(userSongService.removeRecentUserSong(testUsername)).thenReturn(song)
+
+    // When
+    commandService.removeSongCommand(testUsername, testChannel)
+
+    // Then
+    verify(userSongService).removeRecentUserSong(testUsername)
+    verify(messageService)
+      .sendMessage(testChannel, "docJAM @$testUsername Error removing song. Please try again.")
+    verify(playlistService, never()).removeVideo(anyString())
+    verify(timeRestrictionService, never()).resetVideoCooldown(anyString())
+    verify(timeRestrictionService, never()).setLastRemoval(anyString())
+  }
+
+  @Test
+  fun `test removeSongCommand when playlist removal fails`() {
+    // Given
+    val song = mock(UserSong::class.java)
+    val songEntity = mock(Song::class.java)
+
+    `when`(timeRestrictionService.canUserRemoveVideo(testUsername)).thenReturn(true)
+    `when`(song.song).thenReturn(songEntity)
+    `when`(songEntity.link).thenReturn("https://youtu.be/testVideo")
+    `when`(song.title).thenReturn("Test Song Title")
+    `when`(userSongService.removeRecentUserSong(testUsername)).thenReturn(song)
+    `when`(playlistService.removeVideo("https://youtu.be/testVideo")).thenReturn(false)
+
+    // When
+    commandService.removeSongCommand(testUsername, testChannel)
+
+    // Then
+    verify(userSongService).removeRecentUserSong(testUsername)
+    verify(playlistService).removeVideo("https://youtu.be/testVideo")
+    verify(timeRestrictionService, never()).resetVideoCooldown(anyString())
+    verify(timeRestrictionService, never()).setLastRemoval(anyString())
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername Error removing song from playlist. Please try again.",
+      )
+  }
+
+  @Test
+  fun `test removeSongCommand when user cannot remove video due to cooldown`() {
+    // Given
+    `when`(timeRestrictionService.canUserRemoveVideo(testUsername)).thenReturn(false)
+    `when`(timeRestrictionService.timeToNextRemoval(testUsername)).thenReturn("2min 30sec")
+
+    // When
+    commandService.removeSongCommand(testUsername, testChannel)
+
+    // Then
+    verify(messageService)
+      .sendMessage(
+        testChannel,
+        "docJAM @$testUsername You can remove a video every 5 minutes. Time to next removal: 2min 30sec",
+      )
+    verify(userSongService, never()).removeRecentUserSong(anyString())
+    verify(playlistService, never()).removeVideo(anyString())
+    verify(timeRestrictionService, never()).resetVideoCooldown(anyString())
+    verify(timeRestrictionService, never()).setLastRemoval(anyString())
+  }
 }


### PR DESCRIPTION
### Summary
This pull request focuses on renaming the `;remove` command to `;undo` for clarity and updates the help message accordingly. Additionally, the `;remove` command is reintroduced with new functionality, enabling users to remove the most recently added songs within a set time frame (5 minutes). Key changes include:
- Integration of cooldown handling and playlist updates.
- Updates to the database changelog for removal tracking.
- Added corresponding tests to ensure robust functionality.
